### PR TITLE
Ignore non linkable files when symlinking dotfiles

### DIFF
--- a/dotfiles/main.yml
+++ b/dotfiles/main.yml
@@ -62,17 +62,27 @@
         - { name: bundler, version: 1.17.3 }
         - { name: mailcatcher }
 
-    - name: "Create directories for all files"
+    - name: "Generate a list of files"
+      tags: ['files']
+      set_fact:
+        files: |
+          {{
+            lookup('filetree', '.', wantlist=true) |
+            rejectattr('path', 'match', '.*\.DS_Store') |
+            list
+          }}
+
+    - name: "Create directory for file"
       tags: ['files']
       file: path="~/{{ item.path }}" state=directory
       when: item.state == 'directory'
-      with_filetree: "."
+      loop: "{{ files }}"
 
-    - name: "Link all files"
+    - name: "Link file"
       tags: ['files']
       file: src="{{ item.src }}" dest="~/{{ item.path }}" state=link
       when: item.state == 'file'
-      with_filetree: "."
+      loop: "{{ files }}"
 
     - name: "Sync secrets stored in 1password"
       tags: ['secrets']


### PR DESCRIPTION
The `.DS_Store` is a macos file which is added to each folder including the dotfiles folder. When running the ansible playbook, it tries to symlink all files within the `dotfiles/files` folder but fails because it cannot symlink `.DS_Store` to the home directory `~`.

```shell
ansible-playbook -i inventory main.yml --tags files
```