### PR TITLE
Reuse previous directory when opening new tab in iTerm2

### DIFF
--- a/dotfiles/config.yml
+++ b/dotfiles/config.yml
@@ -76,6 +76,7 @@ homebrew_cask_apps:
   - gpg-suite
   - 1password-cli
   - steam
+  - iterm2
 
   # TODO: force reload of the installed fonts (by manually installing one)
   # will make these fonts available

--- a/dotfiles/files/iterm2/Snazzy.json
+++ b/dotfiles/files/iterm2/Snazzy.json
@@ -239,7 +239,7 @@
     "Alpha Component" : 1,
     "Green Component" : 0.91508829593658447
   },
-  "Custom Directory" : "No",
+  "Custom Directory" : "Recycle",
   "Ansi 0 Color" : {
     "Red Component" : 0,
     "Color Space" : "Calibrated",


### PR DESCRIPTION
Without this each new tab or window will start in `~` instead of the previous working directory.