### PR TITLE
Generate docs for solargraph

### DIFF
--- a/dotfiles/config.yml
+++ b/dotfiles/config.yml
@@ -131,10 +131,13 @@ languages:
     global: 2.6.5
     versions:
       - version: 2.6.5
+        # There is no 2.6.5 available in `solargraph available-cores`
+        solargraph: 2.6.1
         gems:
           - { name: bundler, version: 1.17.3 }
           - { name: rubocop, version: 0.73.0 }
       - version: 2.5.3
+        solargraph: 2.5.3
         gems:
           - { name: bundler, version: 2.0.1 }
           - { name: rubocop }

--- a/dotfiles/files/.gemrc
+++ b/dotfiles/files/.gemrc
@@ -1,0 +1,8 @@
+---
+:backtrace: false
+:bulk_threshold: 1000
+:sources:
+- https://rubygems.org/
+:update_sources: true
+:verbose: true
+gem: "--document=yri,yard"

--- a/dotfiles/main.yml
+++ b/dotfiles/main.yml
@@ -84,13 +84,26 @@
         - "{{ languages.ruby.versions }}"
         - gems
 
+    - name: "Install solargraph documentation"
+      tags: ['lang']
+      environment:
+        ASDF_RUBY_VERSION: '{{ item.version }}'
+      command: solargraph download-core {{ item.solargraph }}
+      changed_when: False
+      loop: "{{ languages.ruby.versions }}"
+
+    - name: "Generate YARD documentation for all Ruby versions"
+      tags: ['lang']
+      environment:
+        ASDF_RUBY_VERSION: '{{ item }}'
+      command: yard gems
+      changed_when: False
+      loop: "{{ languages.ruby.versions | map(attribute='version') | list }}"
+
     - name: "Reshim asdf"
       tags: ['lang']
       command: asdf reshim
       changed_when: False
-
-    # TODO: generate documentation with solargraph
-    # TODO: make sure all gems are installed with extra docs `yard gems`
 
     - name: "Generate a list of files"
       tags: ['files']


### PR DESCRIPTION
Documentation of solargraph https://github.com/castwide/solargraph states:

> Solargraph is capable of providing code completion and documentation for gems that have YARD documentation. You can make sure your gems are documented by running yard gems from the command line.

`yard gems` generates documentation for all **_existing_** gems and the line `gem: "--document=yri,yard"` in `.gemrc` makes sure **_new_** gems have documentation. 

This also installs solargraph cores closer to the actual used Ruby versions, so the documentation of Ruby built-in methods are more correct. 