### PR TITLE
Add pstree tool

### DIFF
--- a/dotfiles/config.yml
+++ b/dotfiles/config.yml
@@ -5,7 +5,8 @@ homebrew_installed_packages:
   - kubernetes-cli
   - ansible
 
-  - exiftool
+  - exiftool # show/mutate EXIF information of documents
+  - pstree # show parent/child relationship of processes
 
   - git
   - gpg2


### PR DESCRIPTION
Installs `pstree` which is a useful tool for checking parent / child relationships of processes.

See also https://linux.die.net/man/1/pstree