### PR TITLE
Set docker environment variables from minikube

### DIFF
--- a/dotfiles/files/.minikube/config/config.json
+++ b/dotfiles/files/.minikube/config/config.json
@@ -1,0 +1,11 @@
+{
+    "cpus": 6,
+    "dashboard": false,
+    "disable-driver-mounts": true,
+    "disk-size": "50G",
+    "ingress": true,
+    "memory": 16384,
+    "profile": "development",
+    "registry": true,
+    "vm-driver": "hyperkit"
+}

--- a/dotfiles/files/.zshrc
+++ b/dotfiles/files/.zshrc
@@ -39,6 +39,11 @@ export LC_ALL=en_US.UTF-8
 export EDITOR="emacsclient -s ${HOME}/.emacs.d/server/server"
 export VISUAL="emacsclient -s ${HOME}/.emacs.d/server/server"
 export DOCKER_BUILDKIT=1
+
+if [ -f "${HOME}/.dockerenv" ]; then
+  source "${HOME}/.dockerenv"
+fi
+
 export HISTFILE=~/.zsh_history
 export HISTFILESIZE=100000
 export HISTSIZE=100000

--- a/dotfiles/files/bin/mkube
+++ b/dotfiles/files/bin/mkube
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+minikube start
+echo $(minikube docker-env) > ~/.dockerenv
+source ~/.dockerenv


### PR DESCRIPTION
Setting the docker environment variables from minikube using function
```bash
eval $(minikube docker-env)
```
allows the `docker` cli tool to communicate with the docker daemon inside of minikube.

The output of the function looks like

```bash
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://192.168.64.1:2376"
export DOCKER_CERT_PATH="~/.minikube/certs"
# Run this command to configure your shell:
# eval $(minikube docker-env)
```

Hardcoding the docker environment variables is problematic, due to the `DOCKER_HOST` ip changing as hardcoded ip's are not supported (yet) https://github.com/kubernetes/minikube/issues/951.

The `minikube start` command does not set the docker env as well, so created a wrapper method `mkube` which writes and sources the current docker environment to `.dockerenv`.

