### PR TITLE
Make sure .spacemacs.env represents the Spacemacs environment paths

### DIFF
--- a/dotfiles/files/.spacemacs
+++ b/dotfiles/files/.spacemacs
@@ -483,6 +483,10 @@ This function defines the environment variables for your Emacs session. By
 default it calls `spacemacs/load-spacemacs-env' which loads the environment
 variables declared in `~/.spacemacs.env' or `~/.spacemacs.d/.spacemacs.env'.
 See the header of this file for more information."
+  ;; Here we're making sure only the .spacemacs.env settings matter
+  ;; by clearing the initial values of PATH and exec-path
+  (setenv "PATH" "")
+  (setq exec-path ())
   (spacemacs/load-spacemacs-env)
   (setenv "SSH_AUTH_SOCK" (expand-file-name (getenv "SSH_AUTH_SOCK")))
   )


### PR DESCRIPTION
The `.spacemacs.env` file should represent the paths and environment available in Spacemacs. Though when loading that file the PATH and exec-path are **updated** and not **replaced**. 

This results into `/usr/bin` being in front of the `exec-path`, so system Ruby will be used instead of the `asdf` one. Using system Ruby is bad because the version is almost alway wrong and it's hard to install gems (requires sudo). 