### PR TITLE
Add speedscope for displaying output from profilers for benchmarking

### DIFF
--- a/dotfiles/config.yml
+++ b/dotfiles/config.yml
@@ -111,6 +111,7 @@ languages:
       - name: import-js # spacemacs automatic import helper
       - name: typescript-language-server # lsp for javascript
       - name: typescript # typescript
+      - name: speedscope # profiling presentation
     global: 12.13.0
     versions:
       - version: 12.13.0


### PR DESCRIPTION
Tool that can be used to display output from profilers https://github.com/jlfwong/speedscope. There's an integration with Ruby https://github.com/jlfwong/speedscope/wiki/Importing-from-stackprof-(ruby) using [Stackprof](https://github.com/tmm1/stackprof) a sampling profiler. 