### PR TITLE
Autoformat JSON files on save in Spacemacs

### DIFF
--- a/dotfiles/files/.spacemacs
+++ b/dotfiles/files/.spacemacs
@@ -556,6 +556,9 @@ before packages are loaded."
   ;; disable tags generation for node_modules
   (push "node_modules" projectile-globally-ignored-directories)
 
+  ;; Enable prettier-js-mode for JSON files
+  (add-hook 'json-mode-hook 'prettier-js-mode)
+
   ;; Try to speed up projectile search
   (setq projectile-enable-caching t)
 


### PR DESCRIPTION
Spacemacs has support for https://github.com/prettier/prettier-emacs which uses https://prettier.io/ to autoformats JS, HTML, CSS, YAML, JSON, etc. 

This hook makes sure the `prettier-js-mode` is enabled whenever opening a JSON file. That mode ensures that when a file is saved the prettier binary is run against the file, autoformatting it in place. 