### PR TITLE
Fix Spacemacs paths by expanding all values in `exec-path` (and PATH)

### DIFF
--- a/dotfiles/files/.spacemacs
+++ b/dotfiles/files/.spacemacs
@@ -488,7 +488,15 @@ See the header of this file for more information."
   (setenv "PATH" "")
   (setq exec-path ())
   (spacemacs/load-spacemacs-env)
+
+  ;; Make sure the SSH_AUTH_SOCK environment variable is expanded
   (setenv "SSH_AUTH_SOCK" (expand-file-name (getenv "SSH_AUTH_SOCK")))
+
+  ;; Map all the items in exec-path, call expand-file-name and store it back in exec-path
+  (setq exec-path (map 'list (lambda (x) (expand-file-name x)) exec-path))
+
+  ;; Set the PATH environment variable by joining the items from `exec-path` with `:`
+  (setenv "PATH" (mapconcat 'identity exec-path path-separator))
   )
 
 (defun dotspacemacs/user-init ()


### PR DESCRIPTION
When there's a `~` in the `.spacemacs.env` file (https://github.com/mvgijssel/setup/pull/24) it is not expanded. This means paths are not translated from `~/bin` to `/Users/someuser/bin`.

This means paths are still broken, even after ensuring the `~` paths are in front of `exec-path` (https://github.com/mvgijssel/setup/pull/31). 

This change will map through all the values in `exec-path` and make sure they're expanded.
