### PR TITLE
Update minikube config

### DIFF
--- a/dotfiles/files/.minikube/config/config.json
+++ b/dotfiles/files/.minikube/config/config.json
@@ -1,11 +1,11 @@
 {
-    "cpus": 6,
+    "cpus": 12,
     "dashboard": false,
-    "disable-driver-mounts": true,
+    "disable-driver-mounts": false,
     "disk-size": "50G",
-    "ingress": true,
+    "ingress": false,
     "memory": 16384,
     "profile": "development",
     "registry": true,
-    "vm-driver": "hyperkit"
+    "vm-driver": "vmware"
 }


### PR DESCRIPTION
- Use vmware driver instead of hyperkit to run all VMs in a single (stable) hypervisor
- vmware driver has support for mounts
- More CPUs 💪 
- Disable built-in ingress and dashboard, use custom kubernetes manifests when these are necessary
