### PR TITLE
Use docker for mac docker daemon instead of minikube

### DIFF
--- a/dotfiles/files/.minikube/config/config.json
+++ b/dotfiles/files/.minikube/config/config.json
@@ -5,7 +5,6 @@
     "disk-size": "50G",
     "ingress": false,
     "memory": 16384,
-    "profile": "development",
     "registry": true,
     "vm-driver": "vmware"
 }

--- a/dotfiles/files/.zshrc
+++ b/dotfiles/files/.zshrc
@@ -32,10 +32,6 @@ export EDITOR="emacsclient -s ${HOME}/.emacs.d/server/server"
 export VISUAL="emacsclient -s ${HOME}/.emacs.d/server/server"
 export DOCKER_BUILDKIT=1
 
-if [ -f "${HOME}/.dockerenv" ]; then
-  source "${HOME}/.dockerenv"
-fi
-
 export HISTFILE=~/.zsh_history
 export HISTSIZE=100000 # number of lines loaded into the shell when started
 export SAVEHIST=100000 # number of lines of the .zsh_history file, will be trimmed when exceeded

--- a/dotfiles/files/bin/mkube
+++ b/dotfiles/files/bin/mkube
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-minikube start
-echo $(minikube docker-env) > ~/.dockerenv
-source ~/.dockerenv


### PR DESCRIPTION
Minikube has some performance issues when building certain docker files (https://github.com/kubernetes/minikube/issues/6018). Can use the docker for mac docker daemon for now.

More or less the inverse of https://github.com/mvgijssel/setup/pull/25. 