### PR TITLE
Install Adobe Creative Cloud

### DIFF
--- a/dotfiles/config.yml
+++ b/dotfiles/config.yml
@@ -24,8 +24,6 @@ homebrew_installed_packages:
   - v8@3.15 # the ruby racer gem
   - imagemagick # otherwise Rails image upload no work
 
-  - lastpass-cli
-
   - dnsmasq
 
   # Emacs
@@ -82,6 +80,7 @@ homebrew_cask_apps:
   - steam
   - iterm2
   - rubymine
+  - adobe-creative-cloud
 
   # TODO: force reload of the installed fonts (by manually installing one)
   # will make these fonts available


### PR DESCRIPTION
Adobe Bridge is free software from Adobe which can updates images in batch. For example renaming or updating the metadata (https://www.guidingtech.com/batch-convert-photos-adobe-bridge/).

This is a nice follow-up to https://github.com/mvgijssel/apple-photos-export-timestamp-fix as not all image metadata is correct yet.