### PR TITLE
Setup iPhone tracking using owntracks and ESPHome iBeacons

### DIFF
--- a/home-assistant/config/automations.yaml
+++ b/home-assistant/config/automations.yaml
@@ -619,3 +619,49 @@
       data:
         entity_id: media_player.sonos_move
   mode: single
+- id: '1665418228675'
+  alias: Process Owntracks
+  variables:
+    beacon_mapping: 
+      1:
+        1: supply_closet
+        2: kitchen
+        3: hallway
+        4: driveway
+  description: |
+    example beacon payload
+    {'_type': 'beacon', 'acc': 13, 'major': 1, 'minor': 4, 'prox': 3, 'rssi': -84, 'tid': 'NE', 'tst': 1665465775, 'uuid': '12A13A53-905B-0654-3468-3956014A7888' }
+  trigger:
+  - platform: mqtt
+    topic: owntracks/mqtt/maarten-iphone/beacon
+  condition: []
+  action:
+  - service: variable.set_variable
+    data:
+      value: |
+        {% set current_data = expand("variable.owntracks_data")[0].attributes %}
+        {% set closest_location = (current_data.values() | max(attribute="rssi")).location %}
+        {{ closest_location }}
+      attributes: |
+        {% set location = beacon_mapping[trigger.payload_json.major][trigger.payload_json.minor] %}
+        {% 
+          set data = { 
+            location: {
+              'location': location,
+              'rssi': trigger.payload_json.rssi,
+              'acc': trigger.payload_json.acc,
+              'major': trigger.payload_json.major,
+              'minor': trigger.payload_json.minor,
+              'prox': trigger.payload_json.prox,
+              'tid': trigger.payload_json.tid,
+              'tst': trigger.payload_json.tst,
+              'uuid': trigger.payload_json.uuid,
+            } 
+          }
+        %}
+        {{ data }}
+      replace_attributes: false
+      variable: owntracks_data
+  mode: single
+  trace:
+    stored_traces: 1500

--- a/home-assistant/config/configuration.yaml
+++ b/home-assistant/config/configuration.yaml
@@ -124,6 +124,10 @@ group:
       - switch.baby_room_bed_light
 
 variable:
+  owntracks_data:
+    value: ""
+    restore: true
+
   baby_room_presence:
     value: "off"
     restore: true
@@ -387,28 +391,3 @@ homekit:
     entity_config:
       camera.driveway_doorbell_high:
         name: Oprit Camera
-
-owntracks:
-  waypoints: false
-
-zone:
-  - name: living_room
-    latitude: !secret latitude
-    longitude: !secret longitude
-    radius: 0
-    icon: mdi:school
-  - name: hallway
-    latitude: !secret latitude
-    longitude: !secret longitude
-    radius: 0
-    icon: mdi:school
-  - name: driveway
-    latitude: !secret latitude
-    longitude: !secret longitude
-    radius: 0
-    icon: mdi:school
-  - name: kitchen
-    latitude: !secret latitude
-    longitude: !secret longitude
-    radius: 0
-    icon: mdi:school

--- a/home-assistant/config/configuration.yaml
+++ b/home-assistant/config/configuration.yaml
@@ -387,3 +387,28 @@ homekit:
     entity_config:
       camera.driveway_doorbell_high:
         name: Oprit Camera
+
+owntracks:
+  waypoints: false
+
+zone:
+  - name: living_room
+    latitude: !secret latitude
+    longitude: !secret longitude
+    radius: 0
+    icon: mdi:school
+  - name: hallway
+    latitude: !secret latitude
+    longitude: !secret longitude
+    radius: 0
+    icon: mdi:school
+  - name: driveway
+    latitude: !secret latitude
+    longitude: !secret longitude
+    radius: 0
+    icon: mdi:school
+  - name: kitchen
+    latitude: !secret latitude
+    longitude: !secret longitude
+    radius: 0
+    icon: mdi:school

--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - "./mosquitto-data:/mosquitto"
     ports:
-      - "127.0.0.1:1883:1883"
+      - "0.0.0.0:1883:1883"
       - "127.0.0.1:9001:9001"
     command: "mosquitto -c /mosquitto-no-auth.conf"
 

--- a/home-assistant/esphome-data/.base.yaml
+++ b/home-assistant/esphome-data/.base.yaml
@@ -25,6 +25,7 @@ switch:
     # after reboot, keep the relay off. this prevents light turning on after a power outage
     restore_mode: ALWAYS_OFF
 
+# From https://community.home-assistant.io/t/shelly-plus-1-esphome-bletracker/363549/38
 # Setup a button in home assistant to reboot the shelly into safe mode
 button:
   - platform: safe_mode

--- a/home-assistant/esphome-data/.shelly-1pm-plus.yaml
+++ b/home-assistant/esphome-data/.shelly-1pm-plus.yaml
@@ -4,13 +4,17 @@ esphome:
     board_build.f_cpu: 160000000L
 
 esp32:
-  board: esp32doit-devkit-v1
+  # board: esp32doit-devkit-v1
+  board: esp32dev
   framework:
     type: esp-idf
     sdkconfig_options:
       CONFIG_FREERTOS_UNICORE: y
       CONFIG_ESP32_DEFAULT_CPU_FREQ_160: y
       CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ: "160"
+      CONFIG_ESP_TASK_WDT_TIMEOUT_S: "20"
+      CONFIG_BT_BLE_50_FEATURES_SUPPORTED: n
+      CONFIG_BT_BLE_42_FEATURES_SUPPORTED: y
 
 output:
   - platform: gpio

--- a/home-assistant/esphome-data/.shelly-1pm-plus.yaml
+++ b/home-assistant/esphome-data/.shelly-1pm-plus.yaml
@@ -25,3 +25,9 @@ status_led:
   pin:
     number: GPIO0
     inverted: true
+
+esp32_ble_beacon:
+  type: iBeacon
+  uuid: 12a13a53-905b-0654-3468-3956014a7888
+  major: ${beacon_major}
+  minor: ${beacon_minor}

--- a/home-assistant/esphome-data/.shelly-1pm-plus.yaml
+++ b/home-assistant/esphome-data/.shelly-1pm-plus.yaml
@@ -12,6 +12,9 @@ esp32:
       CONFIG_FREERTOS_UNICORE: y
       CONFIG_ESP32_DEFAULT_CPU_FREQ_160: y
       CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ: "160"
+      # From https://github.com/esphome/issues/issues/2941
+      # Increase watchdog timeout to flash firmware with bluetooth enabled, fixes error:
+      # ERROR Error receiving acknowledge binary size: timed out
       CONFIG_ESP_TASK_WDT_TIMEOUT_S: "20"
       CONFIG_BT_BLE_50_FEATURES_SUPPORTED: n
       CONFIG_BT_BLE_42_FEATURES_SUPPORTED: y

--- a/home-assistant/esphome-data/driveway-shelly.yaml
+++ b/home-assistant/esphome-data/driveway-shelly.yaml
@@ -1,6 +1,8 @@
 substitutions:
   device_name: "driveway-shelly"
   entity_id: "driveway_shelly"
+  beacon_major: 1
+  beacon_minor: 4
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml

--- a/home-assistant/esphome-data/driveway-shelly.yaml
+++ b/home-assistant/esphome-data/driveway-shelly.yaml
@@ -1,8 +1,8 @@
 substitutions:
   device_name: "driveway-shelly"
   entity_id: "driveway_shelly"
-  beacon_major: 1
-  beacon_minor: 4
+  beacon_major: "1"
+  beacon_minor: "4"
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml

--- a/home-assistant/esphome-data/hallway-shelly.yaml
+++ b/home-assistant/esphome-data/hallway-shelly.yaml
@@ -2,6 +2,8 @@ substitutions:
   device_name: "hallway-shelly"
   entity_id: "hallway_shelly"
   light_entity_id: "light.hallway_lights"
+  beacon_major: 1
+  beacon_minor: 3
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml

--- a/home-assistant/esphome-data/hallway-shelly.yaml
+++ b/home-assistant/esphome-data/hallway-shelly.yaml
@@ -2,8 +2,8 @@ substitutions:
   device_name: "hallway-shelly"
   entity_id: "hallway_shelly"
   light_entity_id: "light.hallway_lights"
-  beacon_major: 1
-  beacon_minor: 3
+  beacon_major: "1"
+  beacon_minor: "3"
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml

--- a/home-assistant/esphome-data/kitchen-shelly.yaml
+++ b/home-assistant/esphome-data/kitchen-shelly.yaml
@@ -2,6 +2,8 @@ substitutions:
   device_name: "kitchen-shelly"
   entity_id: "kitchen_shelly"
   light_entity_id: "light.kitchen_lights"
+  beacon_major: 1
+  beacon_minor: 2
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml

--- a/home-assistant/esphome-data/kitchen-shelly.yaml
+++ b/home-assistant/esphome-data/kitchen-shelly.yaml
@@ -2,8 +2,8 @@ substitutions:
   device_name: "kitchen-shelly"
   entity_id: "kitchen_shelly"
   light_entity_id: "light.kitchen_lights"
-  beacon_major: 1
-  beacon_minor: 2
+  beacon_major: "1"
+  beacon_minor: "2"
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml

--- a/home-assistant/esphome-data/supply-closet-shelly.yaml
+++ b/home-assistant/esphome-data/supply-closet-shelly.yaml
@@ -10,3 +10,7 @@ binary_sensor:
   - <<: !include .basic_light_binary_sensor.yaml
     name: ${entity_id}_input
     pin: GPIO4
+
+esp32_ble_beacon:
+  type: iBeacon
+  uuid: 12a13a53-905b-0654-3468-3956014a7888

--- a/home-assistant/esphome-data/supply-closet-shelly.yaml
+++ b/home-assistant/esphome-data/supply-closet-shelly.yaml
@@ -1,6 +1,8 @@
 substitutions:
   device_name: "supply-closet-shelly"
   entity_id: "supply_closet_shelly"
+  beacon_minor: 1
+  beacon_major: 1
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml
@@ -10,7 +12,3 @@ binary_sensor:
   - <<: !include .basic_light_binary_sensor.yaml
     name: ${entity_id}_input
     pin: GPIO4
-
-esp32_ble_beacon:
-  type: iBeacon
-  uuid: 12a13a53-905b-0654-3468-3956014a7888

--- a/home-assistant/esphome-data/supply-closet-shelly.yaml
+++ b/home-assistant/esphome-data/supply-closet-shelly.yaml
@@ -1,8 +1,8 @@
 substitutions:
   device_name: "supply-closet-shelly"
   entity_id: "supply_closet_shelly"
-  beacon_minor: 1
-  beacon_major: 1
+  beacon_major: "1"
+  beacon_minor: "1"
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml


### PR DESCRIPTION
ref #115 

Tried to validate if using Owntracks + beacon ranging with ESPHome iBeacons would work for tracking the iPhone across the house. The automation in home assistant reduces the data received from the mqtt messages sent by owntracks and sets the current location of the device to the one with the lowest bluetooth RSSI. 

This works pretty well if the Owntracks iOS app is running in the foreground, the location updates really quickly (~5 seconds). But if the Owntracks app is running in the background / the iPhone is locked the beacon updates are very minimal (~5 minutes) which is too slow to be useful for presence (or absence) detection.