### PR TITLE
Setup mqtt server authentication and authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ mutagen.yml.lock
 
 /home-assistant/z-stack-firmware/*
 
+/home-assistant/mosquitto-data/*
+!/home-assistant/mosquitto-data/acls
+!/home-assistant/mosquitto-data/mosquitto-auth.conf
+
 .env
 
 .DS_Store

--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -8,7 +8,8 @@ services:
     ports:
       - "127.0.0.1:1883:1883"
       - "127.0.0.1:9001:9001"
-    command: "mosquitto -c /mosquitto-no-auth.conf"
+    command: "mosquitto -c /mosquitto/mosquitto-auth.conf"
+    user: 1000:1000
 
   zigbee2mqtt:
     container_name: zigbee2mqtt

--- a/home-assistant/mosquitto-data/acls
+++ b/home-assistant/mosquitto-data/acls
@@ -1,0 +1,15 @@
+# Home Assistant has access to everything
+user home-assistant
+topic readwrite #
+
+# ESPHome has access to everything
+user esphome
+topic readwrite #
+
+# ZwaveJS2mqtt has access to everything
+user zwavejs2mqtt
+topic readwrite #
+
+# Zigbee2mqtt has access to everything
+user zigbee2mqtt
+topic readwrite #

--- a/home-assistant/mosquitto-data/acls
+++ b/home-assistant/mosquitto-data/acls
@@ -8,8 +8,8 @@ topic readwrite #
 
 # ZwaveJS2mqtt has access to everything
 user zwavejs2mqtt
-topic readwrite #
+topic readwrite zwave/#
 
 # Zigbee2mqtt has access to everything
 user zigbee2mqtt
-topic readwrite #
+topic readwrite zigbee2mqtt/#

--- a/home-assistant/mosquitto-data/mosquitto-auth.conf
+++ b/home-assistant/mosquitto-data/mosquitto-auth.conf
@@ -1,0 +1,4 @@
+allow_anonymous false
+password_file /mosquitto/passwd
+acl_file /mosquitto/acls
+listener 1883

--- a/home-assistant/zigbee2mqtt-data/configuration.yaml
+++ b/home-assistant/zigbee2mqtt-data/configuration.yaml
@@ -3,6 +3,11 @@ availability: true
 mqtt:
   base_topic: zigbee2mqtt
   server: mqtt://mqtt
+  keepalive: 60
+  password: '!secret mqtt_password'
+  reject_unauthorized: true
+  user: zigbee2mqtt
+  version: 4
 serial:
   port: /dev/zigbee
 frontend:


### PR DESCRIPTION
ref #106 

Followed this guide (https://www.chirpstack.io/project/guides/mqtt-authentication/) to setup users + acls in mosquitto. Also reconfigured home-assistant, zigbee2mqtt and zwavejs2mqtt to use the relevant username/password combination.