### PR TITLE
Ensure power on off Shelly relays with linked smart lights 

### DIFF
--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -64,6 +64,6 @@ services:
       - /etc/localtime:/etc/localtime:ro
     restart: always
     privileged: true
+    network_mode: host
     ports:
-      - '127.0.0.1:6052:6052' # port for the UI
-    # network_mode: host
+      - '0.0.0.0:6052:6052' # port for the UI

--- a/home-assistant/esphome-data/.shelly-1pm-plus.yaml
+++ b/home-assistant/esphome-data/.shelly-1pm-plus.yaml
@@ -28,9 +28,3 @@ status_led:
   pin:
     number: GPIO0
     inverted: true
-
-esp32_ble_beacon:
-  type: iBeacon
-  uuid: 12a13a53-905b-0654-3468-3956014a7888
-  major: ${beacon_major}
-  minor: ${beacon_minor}

--- a/home-assistant/esphome-data/.smart_light_restore.yaml
+++ b/home-assistant/esphome-data/.smart_light_restore.yaml
@@ -1,0 +1,22 @@
+time:
+  - platform: homeassistant
+    on_time:
+      - seconds: 0
+        # Every minute
+        minutes: /1
+        then:
+          - if:
+              condition:
+                and:
+                  - wifi.connected:
+                  - api.connected:
+                  - switch.is_off: shelly_relay
+              then:
+                # Turn on the shelly relay with the zigbee lights
+                - switch.turn_on: shelly_relay
+
+                # Immediately turn off the lights
+                - homeassistant.service:
+                    service: light.turn_off
+                    data:
+                      entity_id: ${light_entity_id}

--- a/home-assistant/esphome-data/bathroom-shelly.yaml
+++ b/home-assistant/esphome-data/bathroom-shelly.yaml
@@ -6,6 +6,7 @@ substitutions:
 packages:
   device_base: !include .shelly-1l.yaml
   base: !include .base.yaml
+  smart_light_restore: !include .smart_light_restore.yaml
 
 binary_sensor:
   - <<: !include .smart_light_binary_sensor.yaml

--- a/home-assistant/esphome-data/driveway-shelly.yaml
+++ b/home-assistant/esphome-data/driveway-shelly.yaml
@@ -1,8 +1,6 @@
 substitutions:
   device_name: "driveway-shelly"
   entity_id: "driveway_shelly"
-  beacon_major: "1"
-  beacon_minor: "4"
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml

--- a/home-assistant/esphome-data/hallway-shelly.yaml
+++ b/home-assistant/esphome-data/hallway-shelly.yaml
@@ -6,6 +6,7 @@ substitutions:
 packages:
   device_base: !include .shelly-1pm-plus.yaml
   base: !include .base.yaml
+  smart_light_restore: !include .smart_light_restore.yaml
 
 binary_sensor:
   - <<: !include .smart_light_binary_sensor.yaml

--- a/home-assistant/esphome-data/hallway-shelly.yaml
+++ b/home-assistant/esphome-data/hallway-shelly.yaml
@@ -2,8 +2,6 @@ substitutions:
   device_name: "hallway-shelly"
   entity_id: "hallway_shelly"
   light_entity_id: "light.hallway_lights"
-  beacon_major: "1"
-  beacon_minor: "3"
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml

--- a/home-assistant/esphome-data/kitchen-shelly.yaml
+++ b/home-assistant/esphome-data/kitchen-shelly.yaml
@@ -6,6 +6,7 @@ substitutions:
 packages:
   device_base: !include .shelly-1pm-plus.yaml
   base: !include .base.yaml
+  smart_light_restore: !include .smart_light_restore.yaml
 
 binary_sensor:
   - <<: !include .smart_light_momentary_binary_sensor.yaml

--- a/home-assistant/esphome-data/kitchen-shelly.yaml
+++ b/home-assistant/esphome-data/kitchen-shelly.yaml
@@ -2,8 +2,6 @@ substitutions:
   device_name: "kitchen-shelly"
   entity_id: "kitchen_shelly"
   light_entity_id: "light.kitchen_lights"
-  beacon_major: "1"
-  beacon_minor: "2"
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml

--- a/home-assistant/esphome-data/supply-closet-shelly.yaml
+++ b/home-assistant/esphome-data/supply-closet-shelly.yaml
@@ -1,8 +1,6 @@
 substitutions:
   device_name: "supply-closet-shelly"
   entity_id: "supply_closet_shelly"
-  beacon_major: "1"
-  beacon_minor: "1"
 
 packages:
   device_base: !include .shelly-1pm-plus.yaml

--- a/home-assistant/esphome-data/toilet-shelly.yaml
+++ b/home-assistant/esphome-data/toilet-shelly.yaml
@@ -14,3 +14,26 @@ binary_sensor:
   - <<: !include .smart_light_binary_sensor.yaml
     name: ${entity_id}_input_2
     pin: GPIO14
+
+time:
+  - platform: homeassistant
+    on_time:
+      - seconds: 0
+        # Every minute
+        minutes: /1
+        then:
+          - if:
+              condition:
+                and:
+                  - wifi.connected:
+                  - api.connected:
+                  - switch.is_off: shelly_relay
+              then:
+                # Turn on the shelly relay with the zigbee lights
+                - switch.turn_on: shelly_relay
+
+                # Immediately turn off the lights
+                - homeassistant.service:
+                    service: light.turn_off
+                    data:
+                      entity_id: ${light_entity_id}

--- a/home-assistant/esphome-data/toilet-shelly.yaml
+++ b/home-assistant/esphome-data/toilet-shelly.yaml
@@ -6,6 +6,7 @@ substitutions:
 packages:
   device_base: !include .shelly-1l.yaml
   base: !include .base.yaml
+  smart_light_restore: !include .smart_light_restore.yaml
 
 binary_sensor:
   - <<: !include .smart_light_binary_sensor.yaml
@@ -14,26 +15,3 @@ binary_sensor:
   - <<: !include .smart_light_binary_sensor.yaml
     name: ${entity_id}_input_2
     pin: GPIO14
-
-time:
-  - platform: homeassistant
-    on_time:
-      - seconds: 0
-        # Every minute
-        minutes: /1
-        then:
-          - if:
-              condition:
-                and:
-                  - wifi.connected:
-                  - api.connected:
-                  - switch.is_off: shelly_relay
-              then:
-                # Turn on the shelly relay with the zigbee lights
-                - switch.turn_on: shelly_relay
-
-                # Immediately turn off the lights
-                - homeassistant.service:
-                    service: light.turn_off
-                    data:
-                      entity_id: ${light_entity_id}


### PR DESCRIPTION
ref #106 

This automation ensures that after a power-off, Shellys with an attached smart light will re-enable the relay once wifi/api/home-assistant connectivity has been restored. Immediately after the lights are turned off using home-assistant to prevent lights turning on after a power outage! 