### PR TITLE
Setup Teleport on provisioner

### DIFF
--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -81,19 +81,19 @@ container_pull(
 
 # ------------------------------------ workstation ------------------------------------ #
 
-# https://hub.docker.com/layers/library/ubuntu/focal-20230308/images/sha256-b39db7fc56971aac21dee02187e898db759c4f26b9b27b1d80b6ad32ff330c76?context=explore
+# https://hub.docker.com/layers/library/ubuntu/jammy-20230425/images/sha256-ca5534a51dd04bbcebe9b23ba05f389466cf0c190f1f8f182d7eea92a9671d00?context=explore
 container_pull(
     name = "ubuntu_base_amd64",
-    digest = "sha256:b39db7fc56971aac21dee02187e898db759c4f26b9b27b1d80b6ad32ff330c76",
+    digest = "sha256:ca5534a51dd04bbcebe9b23ba05f389466cf0c190f1f8f182d7eea92a9671d00",
     registry = "index.docker.io",
-    repository = "library/ubuntu:focal-20230308",
+    repository = "library/ubuntu:jammy-20230425",
 )
 
 container_pull(
     name = "ubuntu_base_arm64",
-    digest = "sha256:f92b9de5f10b6e1fcda653f5d02bd6c816386dfb830c71cef95df52b2280cd1c",
+    digest = "sha256:6f8fe7bff0bee25c481cdc26e28bba984ebf72e6152005c18e1036983c01a28b",
     registry = "index.docker.io",
-    repository = "library/ubuntu:focal-20230308",
+    repository = "library/ubuntu:jammy-20230425",
 )
 
 http_file(

--- a/provisioner/BUILD.bazel
+++ b/provisioner/BUILD.bazel
@@ -91,11 +91,13 @@ task(
         setup_env = os.environ.get("SETUP_ENV", 'dev')
 
         if setup_env == 'test':
-            os.environ['VALIDATE_HOST'] = os.environ['CONTAINER_ID']
+            os.environ['VALIDATE_HOST'] = f"docker://root@{os.environ['CONTAINER_ID']}"
+        elif setup_env == 'prod':
+            os.environ['VALIDATE_HOST'] = f"ssh://ubuntu@192.168.1.31"
         else:
-            os.environ['VALIDATE_HOST'] = 'provisioner_dev'
+            os.environ['VALIDATE_HOST'] = f"docker://root@provisioner_dev"
         """),
-        cmd.python_entry_point("pytest:console_main", "-vv", "-ra", "--hosts=\"docker://root@$VALIDATE_HOST\"", "$tests"),
+        cmd.python_entry_point("pytest:console_main", "-vv", "-ra", "--hosts=\"$VALIDATE_HOST\"", "$tests"),
     ],
     env = {
         "tests": cmd.files("test_provisioner.py"),

--- a/provisioner/BUILD.bazel
+++ b/provisioner/BUILD.bazel
@@ -18,6 +18,7 @@ pyinfra_run(
     data = [
         "deploys/microk8s/files/cmdline.txt",
         "deploys/network/files/99_config.yaml",
+        "deploys/teleport/files/teleport.yaml",
     ],
     deploy = "deploy.py",
     inventory = "inventory.py",
@@ -41,6 +42,7 @@ task(
             "docker run",
             "--rm",
             "--detach",
+            "--publish 0.0.0.0:443:443",
             "--tmpfs /run",
             "--tmpfs /run/lock",
             "--tmpfs /tmp",

--- a/provisioner/BUILD.bazel
+++ b/provisioner/BUILD.bazel
@@ -9,6 +9,9 @@ pyinfra_run(
         "deploys/microk8s/tasks/install_microk8s.py",
         "deploys/network/tasks/install_network.py",
         "deploys/teleport/tasks/install_teleport.py",
+        "group_data/dev.py",
+        "group_data/prod.py",
+        "group_data/test.py",
     ],
     args = [
         "--data install_network=True",
@@ -18,7 +21,7 @@ pyinfra_run(
     data = [
         "deploys/microk8s/files/cmdline.txt",
         "deploys/network/files/99_config.yaml",
-        "deploys/teleport/files/teleport.yaml",
+        "deploys/teleport/files/teleport.yaml.j2",
     ],
     deploy = "deploy.py",
     inventory = "inventory.py",
@@ -42,7 +45,7 @@ task(
             "docker run",
             "--rm",
             "--detach",
-            "--publish 0.0.0.0:443:443",
+            "--publish 127.0.0.1:10443:443",
             "--tmpfs /run",
             "--tmpfs /run/lock",
             "--tmpfs /tmp",

--- a/provisioner/BUILD.bazel
+++ b/provisioner/BUILD.bazel
@@ -8,10 +8,12 @@ pyinfra_run(
     srcs = [
         "deploys/microk8s/tasks/install_microk8s.py",
         "deploys/network/tasks/install_network.py",
+        "deploys/teleport/tasks/install_teleport.py",
     ],
     args = [
         "--data install_network=True",
         "--data install_microk8s=True",
+        "--data install_teleport=True",
     ],
     data = [
         "deploys/microk8s/files/cmdline.txt",

--- a/provisioner/BUILD.bazel
+++ b/provisioner/BUILD.bazel
@@ -103,6 +103,7 @@ task(
     deps = [
         requirement("pytest-testinfra"),
         requirement("pyyaml"),
+        requirement("semver"),
     ],
 )
 

--- a/provisioner/deploy.py
+++ b/provisioner/deploy.py
@@ -1,9 +1,13 @@
 from provisioner.deploys.network.tasks.install_network import install_network
 from provisioner.deploys.microk8s.tasks.install_microk8s import install_microk8s
+from provisioner.deploys.teleport.tasks.install_teleport import install_teleport
 from pyinfra import host
 
 if host.data.get("install_network"):
     install_network()
+
+if host.data.get("install_teleport"):
+    install_teleport()
 
 if host.data.get("install_microk8s"):
     install_microk8s()

--- a/provisioner/deploys/microk8s/tasks/install_microk8s.py
+++ b/provisioner/deploys/microk8s/tasks/install_microk8s.py
@@ -67,13 +67,6 @@ def install_microk8s():
         _sudo=True,
     )
 
-    server.shell(
-        name="Add microk8s group to current user",
-        commands=[
-            "newgrp microk8s",
-        ],
-    )
-
     files.directory(
         name="Create and own .kube directory",
         present=True,
@@ -89,6 +82,7 @@ def install_microk8s():
             commands=[
                 "microk8s start",
             ],
+            _sudo=True,
         )
 
         server.shell(
@@ -99,4 +93,5 @@ def install_microk8s():
                 "microk8s enable helm",
                 "microk8s enable hostpath-storage",
             ],
+            _sudo=True,
         )

--- a/provisioner/deploys/microk8s/tasks/install_microk8s.py
+++ b/provisioner/deploys/microk8s/tasks/install_microk8s.py
@@ -26,7 +26,7 @@ def install_microk8s():
         _sudo=True,
         user="root",
         group="root",
-        mode="644",
+        mode="0755",
     )
 
     if config_file.changed and not host.data.get("inside_docker"):

--- a/provisioner/deploys/microk8s/tasks/install_microk8s.py
+++ b/provisioner/deploys/microk8s/tasks/install_microk8s.py
@@ -67,6 +67,13 @@ def install_microk8s():
         _sudo=True,
     )
 
+    server.shell(
+        name="Add microk8s group to current user",
+        commands=[
+            "newgrp microk8s",
+        ],
+    )
+
     files.directory(
         name="Create and own .kube directory",
         present=True,

--- a/provisioner/deploys/network/tasks/install_network.py
+++ b/provisioner/deploys/network/tasks/install_network.py
@@ -21,46 +21,6 @@ def install_network():
         _sudo=True,
     )
 
-    # update iptables with https://lowendspirit.com/discussion/1559/iptables-restore-v1-8-4-legacy-couldnt-load-match-limit-no-such-file-or-directory
-    apt.packages(
-        name="Install iptables",
-        packages=["iptables", "arptables", "ebtables"],
-        latest=True,
-        _sudo=True,
-    )
-
-    legacy_ip_tables = {
-        "iptables": "/usr/sbin/iptables-legacy",
-        "ip6tables": "/usr/sbin/ip6tables-legacy",
-        "arptables": "/usr/sbin/arptables-legacy",
-        "ebtables": "/usr/sbin/ebtables-legacy",
-    }
-
-    for lib, binary in legacy_ip_tables.items():
-        server.shell(
-            name=f"Enable legacy iptables: {lib} - {binary}",
-            commands=[
-                f"update-alternatives --set {lib} {binary}",
-            ],
-            _sudo=True,
-        )
-
-    apt.packages(
-        name="Install Uncomplicated Firewall (ufw)",
-        packages=["ufw"],
-        latest=True,
-        _sudo=True,
-    )
-
-    if not host.data.get("inside_docker"):
-        server.shell(
-            name="Enable firewall",
-            commands=[
-                "ufw enable",
-            ],
-            _sudo=True,
-        )
-
     if config_file.changed:
         server.shell(
             name="Generate netplan",
@@ -74,6 +34,38 @@ def install_network():
                 commands=["netplan apply"],
                 _sudo=True,
             )
+
+    # update iptables with https://lowendspirit.com/discussion/1559/iptables-restore-v1-8-4-legacy-couldnt-load-match-limit-no-such-file-or-directory
+    apt.packages(
+        name="Install iptables",
+        packages=["iptables", "arptables", "ebtables"],
+        latest=True,
+        _sudo=True,
+    )
+
+    apt.packages(
+        name="Install Uncomplicated Firewall (ufw)",
+        packages=["ufw"],
+        latest=True,
+        _sudo=True,
+    )
+
+    server.shell(
+        name="Allow SSH access",
+        commands=[
+            "ufw allow ssh",
+        ],
+        _sudo=True,
+    )
+
+    if not host.data.get("inside_docker"):
+        server.shell(
+            name="Enable firewall",
+            commands=[
+                "ufw enable",
+            ],
+            _sudo=True,
+        )
 
     if not host.data.get("inside_docker"):
         server.hostname(

--- a/provisioner/deploys/network/tasks/install_network.py
+++ b/provisioner/deploys/network/tasks/install_network.py
@@ -36,12 +36,19 @@ def install_network():
             )
 
     # update iptables with https://lowendspirit.com/discussion/1559/iptables-restore-v1-8-4-legacy-couldnt-load-match-limit-no-such-file-or-directory
-    apt.packages(
+    iptables = apt.packages(
         name="Install iptables",
         packages=["iptables", "arptables", "ebtables"],
-        latest=True,
         _sudo=True,
     )
+
+    if iptables.changed and not host.data.get("inside_docker"):
+        server.reboot(
+            name="Reboot the server and wait to reconnect",
+            delay=60,
+            reboot_timeout=600,
+            _sudo=True,
+        )
 
     apt.packages(
         name="Install Uncomplicated Firewall (ufw)",
@@ -62,7 +69,7 @@ def install_network():
         server.shell(
             name="Enable firewall",
             commands=[
-                "ufw enable",
+                "yes | ufw enable",
             ],
             _sudo=True,
         )

--- a/provisioner/deploys/network/tasks/install_network.py
+++ b/provisioner/deploys/network/tasks/install_network.py
@@ -35,21 +35,6 @@ def install_network():
                 _sudo=True,
             )
 
-    # update iptables with https://lowendspirit.com/discussion/1559/iptables-restore-v1-8-4-legacy-couldnt-load-match-limit-no-such-file-or-directory
-    iptables = apt.packages(
-        name="Install iptables",
-        packages=["iptables", "arptables", "ebtables"],
-        _sudo=True,
-    )
-
-    if iptables.changed and not host.data.get("inside_docker"):
-        server.reboot(
-            name="Reboot the server and wait to reconnect",
-            delay=60,
-            reboot_timeout=600,
-            _sudo=True,
-        )
-
     apt.packages(
         name="Install Uncomplicated Firewall (ufw)",
         packages=["ufw"],

--- a/provisioner/deploys/network/tasks/install_network.py
+++ b/provisioner/deploys/network/tasks/install_network.py
@@ -21,6 +21,47 @@ def install_network():
         _sudo=True,
     )
 
+    # update iptables with https://lowendspirit.com/discussion/1559/iptables-restore-v1-8-4-legacy-couldnt-load-match-limit-no-such-file-or-directory
+    if host.data.legacy_ip_tables:
+        apt.packages(
+            name="Install iptables",
+            packages=["iptables", "arptables", "ebtables"],
+            latest=True,
+            _sudo=True,
+        )
+
+        legacy_ip_tables = {
+            "iptables": "/usr/sbin/iptables-legacy",
+            "ip6tables": "/usr/sbin/ip6tables-legacy",
+            "arptables": "/usr/sbin/arptables-legacy",
+            "ebtables": "/usr/sbin/ebtables-legacy",
+        }
+
+        for lib, binary in legacy_ip_tables.items():
+            server.shell(
+                name=f"Enable legacy iptables: {lib} - {binary}",
+                commands=[
+                    f"update-alternatives --set {lib} {binary}",
+                ],
+                _sudo=True,
+            )
+
+    apt.packages(
+        name="Install Uncomplicated Firewall (ufw)",
+        packages=["ufw"],
+        latest=True,
+        _sudo=True,
+    )
+
+    if not host.data.get("inside_docker"):
+        server.shell(
+            name="Enable firewall",
+            commands=[
+                "ufw enable",
+            ],
+            _sudo=True,
+        )
+
     if config_file.changed:
         server.shell(
             name="Generate netplan",
@@ -34,30 +75,6 @@ def install_network():
                 commands=["netplan apply"],
                 _sudo=True,
             )
-
-    apt.packages(
-        name="Install Uncomplicated Firewall (ufw)",
-        packages=["ufw"],
-        latest=True,
-        _sudo=True,
-    )
-
-    server.shell(
-        name="Allow SSH access",
-        commands=[
-            "ufw allow ssh",
-        ],
-        _sudo=True,
-    )
-
-    if not host.data.get("inside_docker"):
-        server.shell(
-            name="Enable firewall",
-            commands=[
-                "yes | ufw enable",
-            ],
-            _sudo=True,
-        )
 
     if not host.data.get("inside_docker"):
         server.hostname(

--- a/provisioner/deploys/teleport/files/teleport.yaml
+++ b/provisioner/deploys/teleport/files/teleport.yaml
@@ -1,0 +1,31 @@
+version: v3
+teleport:
+  nodename: provisioner
+  data_dir: /var/lib/teleport
+  log:
+    output: stderr
+    severity: INFO
+    format:
+      output: text
+  ca_pin: ""
+  diag_addr: ""
+auth_service:
+  enabled: "yes"
+  listen_addr: 0.0.0.0:3025
+  cluster_name: tele.example.com
+  proxy_listener_mode: multiplex
+ssh_service:
+  enabled: "yes"
+  commands:
+    - name: hostname
+      command: [hostname]
+      period: 1m0s
+proxy_service:
+  enabled: "yes"
+  web_listen_addr: 0.0.0.0:443
+  public_addr: tele.example.com:443
+  https_keypairs: []
+  https_keypairs_reload_interval: 0s
+  acme:
+    enabled: "yes"
+    email: user@example.com

--- a/provisioner/deploys/teleport/files/teleport.yaml.j2
+++ b/provisioner/deploys/teleport/files/teleport.yaml.j2
@@ -22,10 +22,8 @@ ssh_service:
 proxy_service:
   enabled: "yes"
   web_listen_addr: 0.0.0.0:443
-  public_addr: localhost:443
-  https_keypairs:
-    []
-    # - key_file: /var/lib/teleport/privkey.pem
-    #   cert_file: /var/lib/teleport/fullchain.pem
+  public_addr: "{{ teleport_public_addr }}"
   https_keypairs_reload_interval: 0s
-  acme: {}
+  acme:
+    enabled: "{{ teleport_acme_enabled }}"
+    email: "{{ teleport_acme_email }}"

--- a/provisioner/deploys/teleport/files/teleport.yaml.j2
+++ b/provisioner/deploys/teleport/files/teleport.yaml.j2
@@ -1,4 +1,3 @@
-version: v3
 teleport:
   nodename: provisioner
   data_dir: /var/lib/teleport
@@ -12,7 +11,7 @@ teleport:
 auth_service:
   enabled: "yes"
   listen_addr: 0.0.0.0:3025
-  cluster_name: tele.example.com
+  cluster_name: localhost
   proxy_listener_mode: multiplex
 ssh_service:
   enabled: "yes"
@@ -23,9 +22,10 @@ ssh_service:
 proxy_service:
   enabled: "yes"
   web_listen_addr: 0.0.0.0:443
-  public_addr: tele.example.com:443
-  https_keypairs: []
+  public_addr: localhost:443
+  https_keypairs:
+    []
+    # - key_file: /var/lib/teleport/privkey.pem
+    #   cert_file: /var/lib/teleport/fullchain.pem
   https_keypairs_reload_interval: 0s
-  acme:
-    enabled: "yes"
-    email: user@example.com
+  acme: {}

--- a/provisioner/deploys/teleport/files/teleport.yaml.j2
+++ b/provisioner/deploys/teleport/files/teleport.yaml.j2
@@ -11,7 +11,7 @@ teleport:
 auth_service:
   enabled: "yes"
   listen_addr: 0.0.0.0:3025
-  cluster_name: localhost
+  cluster_name: provisioner
   proxy_listener_mode: multiplex
 ssh_service:
   enabled: "yes"

--- a/provisioner/deploys/teleport/files/teleport.yaml.j2
+++ b/provisioner/deploys/teleport/files/teleport.yaml.j2
@@ -24,6 +24,6 @@ proxy_service:
   web_listen_addr: 0.0.0.0:443
   public_addr: "{{ teleport_public_addr }}"
   https_keypairs_reload_interval: 0s
-  acme:
-    enabled: "{{ teleport_acme_enabled }}"
-    email: "{{ teleport_acme_email }}"
+  https_keypairs: []
+  acme: 
+    enabled: no

--- a/provisioner/deploys/teleport/tasks/install_teleport.py
+++ b/provisioner/deploys/teleport/tasks/install_teleport.py
@@ -50,8 +50,6 @@ def install_teleport():
         group="root",
         mode="644",
         teleport_public_addr=host.data.teleport_public_addr,
-        teleport_acme_enabled=host.data.teleport_acme_enabled,
-        teleport_acme_email=host.data.teleport_acme_email,
     )
 
     systemd.service(

--- a/provisioner/deploys/teleport/tasks/install_teleport.py
+++ b/provisioner/deploys/teleport/tasks/install_teleport.py
@@ -33,9 +33,10 @@ def install_teleport():
             _sudo=True,
         )
 
-    files.put(
-        name="Copy Teleport config",
-        src="provisioner/deploys/teleport/files/teleport.yaml",
+    # TODO: branch on dev vs prod
+    files.template(
+        name="Create Teleport config",
+        src="provisioner/deploys/teleport/files/teleport.yaml.j2",
         dest="/etc/teleport.yaml",
         create_remote_dir=True,
         _sudo=True,

--- a/provisioner/deploys/teleport/tasks/install_teleport.py
+++ b/provisioner/deploys/teleport/tasks/install_teleport.py
@@ -1,0 +1,14 @@
+from pyinfra.api.deploy import deploy
+from pyinfra.operations import files, server, apt
+from pyinfra import host
+
+
+@deploy("Install Teleport")
+def install_teleport():
+    pass
+    # apt.packages(
+    #     name="Install teleport",
+    #     packages=["teleport"],
+    #     latest=True,
+    #     _sudo=True,
+    # )

--- a/provisioner/deploys/teleport/tasks/install_teleport.py
+++ b/provisioner/deploys/teleport/tasks/install_teleport.py
@@ -11,8 +11,14 @@ def install_teleport():
         _sudo=True,
     )
 
-    # TODO: branch on architecture
-    # TODO: open port 443 for teleport in ufw
+    server.shell(
+        name="Allow HTTPS access",
+        commands=[
+            "ufw allow https",
+        ],
+        _sudo=True,
+    )
+
     # https://goteleport.com/download/#install-links
     TELEPORT_VERSION = "12.2.5"
 

--- a/provisioner/deploys/teleport/tasks/install_teleport.py
+++ b/provisioner/deploys/teleport/tasks/install_teleport.py
@@ -1,6 +1,7 @@
 from pyinfra.api.deploy import deploy
 from pyinfra.operations import files, server, apt
 from pyinfra import host
+from pyinfra.facts.deb import DebPackage
 
 
 @deploy("Install Teleport")
@@ -19,11 +20,14 @@ def install_teleport():
         _sudo=True,
     )
 
-    # https://goteleport.com/download/#install-links
+    teleport = host.get_fact(DebPackage, "teleport")
+
     TELEPORT_VERSION = "12.2.5"
 
-    apt.deb(
-        name="Install Teleport via deb",
-        src=f"https://cdn.teleport.dev/teleport_{TELEPORT_VERSION}_arm64.deb",
-        _sudo=True,
-    )
+    if not teleport or teleport["version"] != TELEPORT_VERSION:
+        # https://goteleport.com/download/#install-links
+        apt.deb(
+            name="Install Teleport via deb",
+            src=f"https://cdn.teleport.dev/teleport_{TELEPORT_VERSION}_arm64.deb",
+            _sudo=True,
+        )

--- a/provisioner/deploys/teleport/tasks/install_teleport.py
+++ b/provisioner/deploys/teleport/tasks/install_teleport.py
@@ -5,10 +5,19 @@ from pyinfra import host
 
 @deploy("Install Teleport")
 def install_teleport():
-    pass
-    # apt.packages(
-    #     name="Install teleport",
-    #     packages=["teleport"],
-    #     latest=True,
-    #     _sudo=True,
-    # )
+    apt.packages(
+        name="Install wget so we can install .deb directly",
+        packages=["wget"],
+        _sudo=True,
+    )
+
+    # TODO: branch on architecture
+    # TODO: open port 443 for teleport in ufw
+    # https://goteleport.com/download/#install-links
+    TELEPORT_VERSION = "12.2.5"
+
+    apt.deb(
+        name="Install Teleport via deb",
+        src=f"https://cdn.teleport.dev/teleport_{TELEPORT_VERSION}_arm64.deb",
+        _sudo=True,
+    )

--- a/provisioner/deploys/teleport/tasks/install_teleport.py
+++ b/provisioner/deploys/teleport/tasks/install_teleport.py
@@ -33,7 +33,6 @@ def install_teleport():
             _sudo=True,
         )
 
-    # TODO: branch on dev vs prod
     files.template(
         name="Create Teleport config",
         src="provisioner/deploys/teleport/files/teleport.yaml.j2",
@@ -43,6 +42,9 @@ def install_teleport():
         user="root",
         group="root",
         mode="644",
+        teleport_public_addr=host.data.teleport_public_addr,
+        teleport_acme_enabled=host.data.teleport_acme_enabled,
+        teleport_acme_email=host.data.teleport_acme_email,
     )
 
     systemd.service(

--- a/provisioner/deploys/teleport/tasks/install_teleport.py
+++ b/provisioner/deploys/teleport/tasks/install_teleport.py
@@ -1,7 +1,7 @@
 from pyinfra.api.deploy import deploy
 from pyinfra.operations import files, server, apt
 from pyinfra import host
-from pyinfra.facts.deb import DebPackage
+from pyinfra.facts.deb import DebPackage, DebArch
 
 
 @deploy("Install Teleport")
@@ -20,6 +20,7 @@ def install_teleport():
         _sudo=True,
     )
 
+    arch = host.get_fact(DebArch)
     teleport = host.get_fact(DebPackage, "teleport")
 
     TELEPORT_VERSION = "12.2.5"
@@ -28,6 +29,6 @@ def install_teleport():
         # https://goteleport.com/download/#install-links
         apt.deb(
             name="Install Teleport via deb",
-            src=f"https://cdn.teleport.dev/teleport_{TELEPORT_VERSION}_arm64.deb",
+            src=f"https://cdn.teleport.dev/teleport_{TELEPORT_VERSION}_{arch}.deb",
             _sudo=True,
         )

--- a/provisioner/deploys/teleport/tasks/install_teleport.py
+++ b/provisioner/deploys/teleport/tasks/install_teleport.py
@@ -36,7 +36,7 @@ def install_teleport():
         )
 
         systemd.daemon_reload(
-            name="Reload systemd in case service file changed",
+            name="Reload systemd daemon in case service file changed",
             _sudo=True,
         )
 

--- a/provisioner/deploys/teleport/tasks/install_teleport.py
+++ b/provisioner/deploys/teleport/tasks/install_teleport.py
@@ -1,5 +1,5 @@
 from pyinfra.api.deploy import deploy
-from pyinfra.operations import files, server, apt
+from pyinfra.operations import files, server, apt, systemd
 from pyinfra import host
 from pyinfra.facts.deb import DebPackage, DebArch
 
@@ -32,3 +32,23 @@ def install_teleport():
             src=f"https://cdn.teleport.dev/teleport_{TELEPORT_VERSION}_{arch}.deb",
             _sudo=True,
         )
+
+    files.put(
+        name="Copy Teleport config",
+        src="provisioner/deploys/teleport/files/teleport.yaml",
+        dest="/etc/teleport.yaml",
+        create_remote_dir=True,
+        _sudo=True,
+        user="root",
+        group="root",
+        mode="644",
+    )
+
+    systemd.service(
+        name="Restart and enable the teleport service",
+        service="teleport.service",
+        running=True,
+        restarted=True,
+        enabled=True,
+        _sudo=True,
+    )

--- a/provisioner/deploys/teleport/tasks/install_teleport.py
+++ b/provisioner/deploys/teleport/tasks/install_teleport.py
@@ -23,13 +23,20 @@ def install_teleport():
     arch = host.get_fact(DebArch)
     teleport = host.get_fact(DebPackage, "teleport")
 
-    TELEPORT_VERSION = "12.2.5"
+    TELEPORT_VERSION = "12.3.1"
 
-    if not teleport or teleport["version"] != TELEPORT_VERSION:
+    needs_update = not teleport or teleport["version"] != TELEPORT_VERSION
+
+    if needs_update:
         # https://goteleport.com/download/#install-links
         apt.deb(
             name="Install Teleport via deb",
             src=f"https://cdn.teleport.dev/teleport_{TELEPORT_VERSION}_{arch}.deb",
+            _sudo=True,
+        )
+
+        systemd.daemon_reload(
+            name="Reload systemd in case service file changed",
             _sudo=True,
         )
 

--- a/provisioner/group_data/dev.py
+++ b/provisioner/group_data/dev.py
@@ -1,4 +1,2 @@
 inside_docker = True
 teleport_public_addr = "127.0.0.1:10443"
-teleport_acme_enabled = "no"
-teleport_acme_email = ""

--- a/provisioner/group_data/dev.py
+++ b/provisioner/group_data/dev.py
@@ -1,0 +1,4 @@
+inside_docker = True
+teleport_public_addr = "127.0.0.1:10443"
+teleport_acme_enabled = "no"
+teleport_acme_email = ""

--- a/provisioner/group_data/dev.py
+++ b/provisioner/group_data/dev.py
@@ -1,2 +1,3 @@
 inside_docker = True
+legacy_ip_tables = True
 teleport_public_addr = "127.0.0.1:10443"

--- a/provisioner/group_data/prod.py
+++ b/provisioner/group_data/prod.py
@@ -1,5 +1,3 @@
 inside_docker = False
 ssh_user = "ubuntu"
 teleport_public_addr = "tele.vgijssel.nl:443"
-teleport_acme_enabled = "yes"
-teleport_acme_email = "haves_borzoi_0o@icloud.com"

--- a/provisioner/group_data/prod.py
+++ b/provisioner/group_data/prod.py
@@ -1,3 +1,4 @@
 inside_docker = False
+legacy_ip_tables = False
 ssh_user = "ubuntu"
 teleport_public_addr = "tele.vgijssel.nl:443"

--- a/provisioner/group_data/prod.py
+++ b/provisioner/group_data/prod.py
@@ -1,0 +1,5 @@
+inside_docker = False
+ssh_user = "ubuntu"
+teleport_public_addr = "tele.vgijssel.nl:443"
+teleport_acme_enabled = "yes"
+teleport_acme_email = "haves_borzoi_0o@icloud.com"

--- a/provisioner/group_data/test.py
+++ b/provisioner/group_data/test.py
@@ -1,4 +1,2 @@
 inside_docker = True
 teleport_public_addr = "127.0.0.1:10443"
-teleport_acme_enabled = "no"
-teleport_acme_email = ""

--- a/provisioner/group_data/test.py
+++ b/provisioner/group_data/test.py
@@ -1,0 +1,4 @@
+inside_docker = True
+teleport_public_addr = "127.0.0.1:10443"
+teleport_acme_enabled = "no"
+teleport_acme_email = ""

--- a/provisioner/group_data/test.py
+++ b/provisioner/group_data/test.py
@@ -1,2 +1,3 @@
 inside_docker = True
+legacy_ip_tables = True
 teleport_public_addr = "127.0.0.1:10443"

--- a/provisioner/inventory.py
+++ b/provisioner/inventory.py
@@ -4,7 +4,7 @@ setup_env = os.environ.get("SETUP_ENV", "dev")
 
 if setup_env == "prod":
     prod = [
-        ("@ssh/provisioner.local"),
+        ("@ssh/192.168.1.31"),
     ]
 
 elif setup_env == "test":

--- a/provisioner/inventory.py
+++ b/provisioner/inventory.py
@@ -3,18 +3,18 @@ import os
 setup_env = os.environ.get("SETUP_ENV", "dev")
 
 if setup_env == "prod":
-    hosts = [
-        ("@ssh/provisioner.local", {"ssh_user": "ubuntu"}),
+    prod = [
+        ("@ssh/provisioner.local"),
     ]
 
 elif setup_env == "test":
     container_id = os.environ["CONTAINER_ID"]
-    hosts = [
-        (f"@docker/{container_id}", {"inside_docker": True}),
+    test = [
+        (f"@docker/{container_id}"),
     ]
 
 else:
     container_id = "provisioner_dev"
-    hosts = [
-        (f"@docker/{container_id}", {"inside_docker": True}),
+    dev = [
+        (f"@docker/{container_id}"),
     ]

--- a/provisioner/inventory.py
+++ b/provisioner/inventory.py
@@ -4,7 +4,7 @@ setup_env = os.environ.get("SETUP_ENV", "dev")
 
 if setup_env == "prod":
     hosts = [
-        ("@ssh/192.168.1.31", {"ssh_user": "ubuntu"}),
+        ("@ssh/provisioner.local", {"ssh_user": "ubuntu"}),
     ]
 
 elif setup_env == "test":

--- a/provisioner/test_provisioner.py
+++ b/provisioner/test_provisioner.py
@@ -32,14 +32,14 @@ def test_cmdline(host):
     assert cmdline.contains("root")
     assert cmdline.user == "root"
     assert cmdline.group == "root"
-    assert cmdline.mode == 0o644
+    assert cmdline.mode == 0o755
 
 
 def test_ubuntu_focal(host):
     assert host.system_info.type == "linux"
     assert host.system_info.distribution == "ubuntu"
-    assert host.system_info.release == "20.04"
-    assert host.system_info.codename == "focal"
+    assert host.system_info.release == "22.04"
+    assert host.system_info.codename == "jammy"
 
 
 def test_microk8s_installed(host):

--- a/provisioner/test_provisioner.py
+++ b/provisioner/test_provisioner.py
@@ -1,5 +1,5 @@
 import yaml
-import re
+import semver
 
 
 def test_netplan_installed(host):
@@ -68,3 +68,27 @@ def test_passwd_file(host):
     assert passwd.user == "root"
     assert passwd.group == "root"
     assert passwd.mode == 0o644
+
+
+def test_wget_installed(host):
+    wget = host.package("wget")
+    assert wget.is_installed
+
+
+def test_teleport_installed(host):
+    teleport = host.package("teleport")
+    assert teleport.is_installed
+
+    server_version = semver.VersionInfo.parse(teleport.version)
+    wanted_version = semver.VersionInfo.parse("12.3.1")
+    assert server_version >= wanted_version
+
+
+def test_teleport_service(host):
+    teleport = host.service("teleport")
+    assert teleport.is_running
+    assert teleport.is_enabled
+
+
+def test_https_port_is_open(host):
+    assert host.socket("tcp://0.0.0.0:443").is_listening

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ pytest-homeassistant-custom-component==0.11.20;
 tzdata==2023.3;
 pyinfra==2.6.2
 sqlalchemy==1.4.40;
+semver==2.13.0;

--- a/requirements.lock
+++ b/requirements.lock
@@ -1191,6 +1191,7 @@ semver==2.13.0 \
     --hash=sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4 \
     --hash=sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f
     # via
+    #   -r ./requirements.in
     #   pulumi
     #   pulumi-command
     #   pulumi-kubernetes

--- a/workstation/deploys/terminal/files/sheldon/plugins.lock
+++ b/workstation/deploys/terminal/files/sheldon/plugins.lock
@@ -1,11 +1,8 @@
-version = "0.6.6"
+version = "0.7.1"
 home = "/Users/maarten"
 config_dir = "/Users/maarten/.sheldon"
 data_dir = "/Users/maarten/.sheldon"
 config_file = "/Users/maarten/.sheldon/plugins.toml"
-lock_file = "/Users/maarten/.sheldon/plugins.lock"
-clone_dir = "/Users/maarten/.sheldon/repos"
-download_dir = "/Users/maarten/.sheldon/downloads"
 
 [[plugins]]
 name = "pure"
@@ -36,18 +33,9 @@ name = "atuin"
 source_dir = "/Users/maarten/.sheldon/repos/github.com/ellie/atuin"
 files = ["/Users/maarten/.sheldon/repos/github.com/ellie/atuin/atuin.plugin.zsh"]
 apply = ["source"]
-[templates.PATH]
-value = "export PATH=\"{{ dir }}:$PATH\""
-each = false
 
-[templates.path]
-value = "path=( \"{{ dir }}\" $path )"
-each = false
-
-[templates.fpath]
-value = "fpath=( \"{{ dir }}\" $fpath )"
-each = false
-
-[templates.source]
-value = "source \"{{ file }}\""
-each = true
+[templates]
+PATH = "export PATH=\"{{ dir }}:$PATH\""
+path = "path=( \"{{ dir }}\" $path )"
+fpath = "fpath=( \"{{ dir }}\" $fpath )"
+source = "{% for file in files %}source \"{{ file }}\"\n{% endfor %}"

--- a/workstation/deploys/utilities/tasks/install_utilities.py
+++ b/workstation/deploys/utilities/tasks/install_utilities.py
@@ -32,6 +32,7 @@ def install_utilities():
         packages=[
             "awscli",
             "dive",  # to check contents of docker layers
+            "mkcert",
         ],
         present=True,
         update=False,


### PR DESCRIPTION
closes #218 

### TODO

- [x] branch teleport installation on architecture
- [x] open port 443 in ufw for teleport
- [x] only install teleport if not already present and version is different
- [x] figure out bug (could be due to invalid certificate)
```
May 01 07:57:38 provisioner teleport[1854]: Original Error: *errors.errorString tls: client offered only unsupported versions: [301]
```
- [x] Setup proper dev config for Teleport
- [x] Setup proper production config for Teleport
- [x] Setup tests for Teleport