### PR TITLE
Fix metric overlap Teleport health check

### DIFF
--- a/provisioner/deploys/teleport/files/teleport_health_check.conf
+++ b/provisioner/deploys/teleport/files/teleport_health_check.conf
@@ -1,4 +1,6 @@
 [[inputs.http_response]]
+  interval = "10s"
+  tagexclude = ["result"]
   urls = ["http://localhost:3000/healthz"]
   response_timeout = "5s"
   method = "GET"

--- a/provisioner/deploys/teleport/files/teleport_health_check.conf
+++ b/provisioner/deploys/teleport/files/teleport_health_check.conf
@@ -1,6 +1,6 @@
 [[inputs.http_response]]
   interval = "10s"
-  tagexclude = ["result"]
+  tagexclude = ["result", "status_code"]
   urls = ["http://localhost:3000/healthz"]
   response_timeout = "5s"
   method = "GET"

--- a/provisioner/deploys/teleport/files/teleport_health_check.conf
+++ b/provisioner/deploys/teleport/files/teleport_health_check.conf
@@ -1,5 +1,6 @@
 [[inputs.http_response]]
   interval = "10s"
+  # Need to remove these tags to prevent overlapping metrics due to stale timeseries.
   tagexclude = ["result", "status_code"]
   urls = ["http://localhost:3000/healthz"]
   response_timeout = "5s"


### PR DESCRIPTION
ref #275 

Based on https://promcon.io/2017-munich/slides/staleness-in-prometheus-2-0.pdf decided to remove some tags from the http_response Telegraf input which results in the expected graph in Logz.io when stopping / starting teleport 🎉 

![image](https://github.com/mvgijssel/setup/assets/6029816/6d6307e7-257e-4381-b797-5b7c871730fc)
